### PR TITLE
Update chat-spammer-secret.lua

### DIFF
--- a/chat-spammer-secret.lua
+++ b/chat-spammer-secret.lua
@@ -1,308 +1,99 @@
--- messages
+secret.notify("Check secret console", 1)
+secret.log("[chat-spammer.lua] If you've switched servers and the spammer isn't working, press clear elements and then execute in client state again", 1, false)
+-- Boxs and shit
+secret.create_slider("lua", "elements", "Spam Rate", 1, 5, "sRate")
+secret.create_checkbox("lua", "elements", "OinkSpam/Advert", "bOink")
+secret.create_checkbox("lua", "elements", "HvHSpam", "bHvH")
+secret.create_checkbox("lua", "elements", "ToxicSpam", "bToxic")
+secret.create_checkbox("lua", "elements", "gir489Quotes (Extreme Racism)", "bGir")
+secret.create_checkbox("lua", "elements", "BibleSpam", "bBible")
+secret.create_checkbox("lua", "elements", "CheadlewareSpam", "bCheadleware")
+secret.create_checkbox("lua", "elements", "NewGenSpam", "bNewGen")
+secret.create_checkbox("lua", "elements", "RyanFournierSpam", "bRyanFournier")
+secret.create_checkbox("lua", "elements", "FemboySpam (Extreme NSFW)", "bFemboy")
+secret.create_checkbox("lua", "elements", "ShabeelSpam", "bShabeel")
+secret.create_checkbox("lua", "elements", "CatSpam", "bCat")
+secret.create_checkbox("lua", "elements", "SecretServiceSpam", "bSecretService")
+secret.create_checkbox("lua", "elements", "CustomSpam", "bCustom")
+secret.create_checkbox("lua", "elements", "OOCSpam", "bOOC")
 
-local OINK_CHATMESSAGES = {
-    "OINK.INDUSTRIES ON TOP, USE OINK.INDUSTRIES!",
-    "Today's Killing Spree Is Sponsored By Oink.Industries!",
-    "owned by oink. buy oink at oink.industries",
-    "OINK OINK OINK OINK OINK OINK OINK OINK",
-    "40 per year, 12 per month. cheap price for extra skill.",
-    "chat is he using oink.industries?",
-	"oink.industries - leading the cheating scene in 2023.",
-	"you can buy a better cheat at oink.industries"
-}
-
-local HVHTALK_CHATMESSAGES = {
-	"ur literally dog shit at this game!!!!!!",
-	"nn dog? nn dog? nn dog? nn dog? nn dog? nn dog? ",
-	[["why am i missing so much?!?!?!?!?" no fake angles in 2k23????]],
-	"you can buy a better cheat at secretservice.club",
-	"im winning too much bro. change up ur settings so u can beat me!!!!!!!!!",
-	"using idiotbox?",
-	"is ur nospread and norecoil working???",
-	"nice aa retard lmao",
-	"DID YOU SEE THAT BACKTRACK RIGHT THERE???",
-	"secretservice.club > your cheat"
-}
-
-local TOXICTALK_CHATMESSAGES = {
-	"HOLY SHIT YALL ARE HORRIBLE WTF",
-	"MY KD IS SO MUCH BETTER THAN YOURS LOOOOOOOL",
-	"YOU WANT TO 1V1 KID? ILL SLAP YOU LIKE YOUR MOTHER",
-	"EZZZZZZZZZZZZZZZZZ EZZZZZZZZZZZZZ NO OINK NO TALK",
-	[["YO WHAT CHEAT IS THAT WHAT CHEAT" SECRETSERVICE.CLUB ON TOPPPP]],
-	"crash! poof! gone! vaporized! destroyed!",
-	"lol you literally got owned by a child.",
-	"I WILL DOMINATE YOU BECAUSE IM YOUR MASTER, KITTEN...",
-	"HAHAHAHHAHAH OWNEDDDDDDDDDDDDDDDDD",
-	"FEELS LIKE TACOBOT.TF. IN REALITY, IM JUST BETTER."
-}
-
-local BIBLE_CHATMESSAGES = {
-	[["Ask and it will be given to you." - Jesus (Matthew 7:7)]],
-	[["Faith can move mountains." - Jesus (Matthew 17:20)]],
-	[["I am the way, the truth, and the life." - Jesus (John 14:6)]],
-	[["Cast your cares on the Lord." - David (Psalm 55:22)]],
-	[["Seek and you will find." - Jesus (Matthew 7:7)]],
-	[["The Lord is my light and salvation." - David (Psalm 27:1)]],
-	[["Love covers a multitude of sins." - Peter (1 Peter 4:8)]],
-	[["Do not worry, for I am with you." - Isaiah (Isaiah 41:10)]],
-	[["A soft answer turns away wrath." - Solomon (Proverbs 15:1)]],
-	[["Trust in the Lord with all your heart." - Solomon (Proverbs 3:5)]],
-	[["I can do everything through Him." - Paul (Philippians 4:13)]],
-	[["He heals the brokenhearted." - David (Psalm 147:3)]],
-	[["The word of God is living and active." - Paul (Hebrews 4:12)]],
-	[["Give thanks in all circumstances." - Paul (1 Thessalonians 5:18)]],
-	[["The Lord will fight for you." - Moses (Exodus 14:14)]]
-}
-	
-local CHEADLEWARE_CHATMESSAGES = {
-    "Cheadleware on top! Buy now on cheadleware.net",
-    "she cheadle on my software whilst spy caming on them hoes with screengrab proof visuals",
-    "This server has been backdoored by cheadleware. Please be scared I need attention",
-    "UKRAINE PIG OWNS YOU!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!",
-    "Cheadleware merch coming soon!",
-    "BUY CHEADLEWARE BUY CHEADLEWARE BUY CHEADLEWARE BUY CHEADLEWARE BUY CHEADLEWARE BUY CHEADLEWARE",
-    "Did you know you can buy cheadleware for 40 dollars only? It's lifetime too. It's kinda crazy...",
-    "https://i.imgur.com/lIa2bkE.png cheadlware cake looks so good. you want a slice?",
-    "cheadleware.net",
-    "cheadleware.net cheadleware.net cheadleware.net cheadleware.net cheadleware.net cheadleware.net cheadleware.net"
-}
-
-local NEWGEN_CHATMESSAGES = {
-    "Skibidi Dop Dop Dop Yes Yes? Skibidi Dopolo Diep Diep?",
-    "Sticking Out Your Gyat For The Rizzler, You're So Skibidi, So Fanum Tax.",
-    "OH MY GOOWDDDDDDD LOOK AT THAT GYATTTTTTT",
-    "PLEASE NO PROTECT ME FROM THE CAMERAMEN THEY ATTACK ME AND FAMILY OF SKIBIDI TOILETS HELP MEEEEEEEEE",
-    "SKIBIDI OWNS YOUR SERVER AND GM_BIGCITY. YOU HAVE NO ESCAPE MUAHAHAHAHAHAHHAHAHHAHHAHAHHHAAAAAA",
-    "I just wanna be your sigma, Freaking come here, Give me your ohio.",
-    "You're not a sigma male like me. You're a fat loser. Escape the matrix with hustlers university 2.0...",
-    "That's so fruity uwu",
-    "Did it hurt? When you fell out of heaven? Generated by RizzApp.io",
-    "ULTIMATE RIZZ LOADING... 5%... 30%... 70%... 99%... ERROR, SKIBIDI TOILET HACKER DETECTED DEFENDING ATTACK!!!",
-    "womp womp"
-}
-
-local RYANFOURNIER_CHATMESSAGES = {
-    "Your server has been backdoored by evil ryan fournier. Changing level to prometheus_berlin_v2...",
-    "Evil Ryan Fournier has access to your computer. Your firewall has been jumped. Say goodbye to your files...",
-    "IM GONNA PISTOL WHIP THE SHIT OUT OF YOU HAHAHAHAHAHAHAHAHAHAHAH",
-    "Students4Trump Sponsors this daily segment of raping garry's mod servers. Please donate to our ORG.",
-    "My wife was my first target, this server is my second target. *he grips his gun harder and harder*",
-    "Injecting evil_ryan_fournier_backdoor_services_dll_main_application.exe into server code...",
-    "RATTED BY EVILRYANFOURNIER! evilryanfournier.com!"
-}
-
-local FEMBOY_CHATMESSAGES = {
-    "h-hey. I'm a small little femboy. D-do you want to co-orrupt me? I'm a si-ssy femboy.",
-    "I'm into tall and big guys so they can hold me and tell me how much of a good boy I am...",
-    "p-p-PLEASE MAASTER GI-IIIVE ME MO-RE O-OF THAT *moaning*",
-    "I'm my master's little s-slut. He can do whatever he wants to me and my b-b-body...",
-    "I have my vibrator set to low as we speak... I-it feels so go-oood",
-    "Master here. My helpless little slut here is such a good girl... He always begs for more like a good soul...",
-    "Being a submissive little femboy slut feels so good. I like not having rights.",
-    "You can p-pinch and twist both of my nipples. They're very sensitive and round.",
-    "I remember when I was t-ied up for hours with a dildo pumping into me. My a-ass has never been the same...",
-    "I'm the #385923th cumdump in the world. You can use me for free uwu.",
-    "P-Please DM me on discord. My name is 'iamleigh_'. E-Dating Prices are 5-10€ an hour."
-}
-
-local SHABEEL_CHATMESSAGES = {
-    "OWNED BY SHABEEL EXPLOITS - discord.gg/gaminglight",
-    "This server has officially been raided by shabeel. May allah power him through gmod servers",
-    "discord.gg/gaminglight",
-    "SHABEEL OWNS YOUUUUUUUUUUUUUUUUUUUUUUUUUU",
-    "youtube.com/@ShabeelExploits I love this youtube channel can someone help me find them?",
-    "Hello I have downloaded server packet via epic exploit server is being backdoored SHABEEL WINNING",
-    "SHABEEL ON TOP OWNED BY SHABEEL"
-}
-
-local CAT_CHATMESSAGES = {
-	"meow",
-	"meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow",
-	"prrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr",
-	"WHO LEFT THE ENGINE RUNNINGGGG",
-	"wake up, eep.",
-	"Today's Chat Spam Is Brough To You By The One And Only Thousand Meow Stare",
-	"growling noises are soooooo cute grrrrrprrrr"
-}
-
-local SECRET_CHATMESSAGES = {
-	"secretservice on top! get at secretservice.club",
-	"Get Good, Get secretservice.club",
-	"Want the best gmod cheat, Get secretservice.club",
-	"SecretService.club owns you!!",
-	"SecretService.club owns me!! UwU",
-	"SecretService.club SecretService.club SecretService.club SecretService.club SecretService.club SecretService.club",
-	"SecretService.club > any cheat",
-	"1v1 me bro, SecretService.club on TOPP!!!",
-	"YOU WISH YOU HAVE SECRETSERVICE.CLUB",
-	"https://imgur.com/a/qZrfSrO SECRETSERVICE.CLUB OWNS YOU!!!",
-	"LSAC? ROTAC? never heard of it, SECRETSERVICE.CLUB ON TOP!!",
-	"hitting this secretservice.club OG joint"
-}
-
-local CUSTOM_CHATMESSAGES = { -- replace with whatever
-	"replace with custom message here",
-	"replace with custom message here",
-	"replace with custom message here",
-	"replace with custom message here",
-	"replace with custom message here",
-	"replace with custom message here",
-	"replace with custom message here",
-	"replace with custom message here",
-	"replace with custom message here",
-	"replace with custom message here",
-	"replace with custom message here",
-	"replace with custom message here"
-}
-
-
--- context, buttons, blah blah blah
-
-secret.create_button("lua", "elements", "oink spam/advert", "bOink") -- we do buttons because i couldn't get checkboxes to work with timers
-secret.create_button("lua", "elements", "hvh talk", "bHvh")
-secret.create_button("lua", "elements", "toxic talk", "bToxic")
-secret.create_button("lua", "elements", "bible quotes", "bBible")
-secret.create_button("lua", "elements", "gir489 quotes (extreme racism)", "bGir")
-secret.create_button("lua", "elements", "cheadle spam", "bCheadle")
-secret.create_button("lua", "elements", "newgen spam", "bNewgen")
-secret.create_button("lua", "elements", "ryan fournier spam", "bFournier")
-secret.create_button("lua", "elements", "femboy spam (extreme nsfw)", "bFemboy")
-secret.create_button("lua", "elements", "shabeel spam", "bShabeel")
-secret.create_button("lua", "elements", "cat spam", "bMeow")
-secret.create_button("lua", "elements", "secret spam/advert", "bSecret")
-secret.create_button("lua", "elements", "custom spam", "bCustom")
-
-
-secret.create_slider("lua", "elements", "rate (seconds)", 1, 5, "sRate")
-
-secret.create_button("lua", "elements", "destroy all timers", "bDestroy")
-
--- insert ooc checkbox here, again I dont have sercet's api - shiba
-
-hook.Remove("Think", "hSpammer")
-hook.Add("Think", "hSpammer", function()
-
-    local _sRate = secret.config_get("sRate")
-
-	if secret.config_get("bOink") then
-		timer.Create( "oink_spammer", _sRate, 0, function()
-			local spamOink = OINK_CHATMESSAGES[math.random(#OINK_CHATMESSAGES)]
-			RunConsoleCommand("say", spamOink)
-			
-		end)
-	end
-
-	if secret.config_get("bHvh") then
-		timer.Create( "hvh_spammer", _sRate, 0, function() -- originally it was "rate" but I fixed it I think lifeline was pasting it from chat-spammer-oink.lua \\ lifeline here, hes right (femboys make mistakes uwu)
-			local spamHVH = HVHTALK_CHATMESSAGES[math.random(#HVHTALK_CHATMESSAGES)]
-			RunConsoleCommand("say", spamHVH)
-			
-		end)
-	end
-
-	if secret.config_get("bToxic") then
-		timer.Create( "toxic_spammer", _sRate, 0, function()
-			local spamToxic = TOXICTALK_CHATMESSAGES[math.random(#TOXICTALK_CHATMESSAGES)]
-			RunConsoleCommand("say", spamToxic)
-			
-		end)
-	end
-
-	if secret.config_get("bBible") then
-		timer.Create( "bible_spammer", _sRate, 0, function()
-			local spamBible = BIBLE_CHATMESSAGES[math.random(#BIBLE_CHATMESSAGES)]
-			RunConsoleCommand("say", spamBible)
-			
-		end)
-	end
-
-	if secret.config_get("bGir") then
-        secret.notify("gir489_spammer timer couldn't start")
-        secret.notify("check secret console for more info")
-        secret.log("[chat-spammer.lua] to be in compliance of github's acceptable use policies, this spammer is removed.", 1)
-        secret.log("[chat-spammer.lua] if you want the uncensored version, you can ask lifeline4603 on discord or do one yourself.", 1)
-	end
-
-    if secret.config_get("bCheadle") then
-		timer.Create( "cheadle_spammer", _sRate, 0, function()
-			local spamCheadle = CHEADLEWARE_CHATMESSAGES[math.random(#CHEADLEWARE_CHATMESSAGES)]
-			RunConsoleCommand("say", spamCheadle)
-			
-		end)
-	end
-
-	if secret.config_get("bNewgen") then
-		timer.Create( "newgen_spammer", _sRate, 0, function()
-			local spamNewgen = NEWGEN_CHATMESSAGES[math.random(#NEWGEN_CHATMESSAGES)]
-			RunConsoleCommand("say", spamNewgen)
-			
-		end)
-	end
-
-	if secret.config_get("bFournier") then
-		timer.Create( "fournier_spammer", _sRate, 0, function()
-			local spamFournier = RYANFOURNIER_CHATMESSAGES[math.random(#RYANFOURNIER_CHATMESSAGES)]
-			RunConsoleCommand("say", spamFournier)
-			
-		end)
-	end
-
-	if secret.config_get("bFemboy") then
-		timer.Create( "femboy_spammer", _sRate, 0, function()
-			local spamFemboy = FEMBOY_CHATMESSAGES[math.random(#FEMBOY_CHATMESSAGES)]
-			RunConsoleCommand("say", spamFemboy)
-			
-		end)
-	end
-
-	if secret.config_get("bShabeel") then
-		timer.Create( "shabeel_spammer", _sRate, 0, function()
-			local spamShabeel = SHABEEL_CHATMESSAGES[math.random(#SHABEEL_CHATMESSAGES)]
-			RunConsoleCommand("say", spamShabeel)
-			
-		end)
-	end
-
-	if secret.config_get("bMeow") then
-		timer.Create( "cat_spammer", _sRate, 0, function()
-			local spamCat = CAT_CHATMESSAGES[math.random(#CAT_CHATMESSAGES)]
-			RunConsoleCommand("say", spamCat)
-			
-		end)
-	end
-
-	if secret.config_get("bSecret") then
-		timer.Create( "secret_spammer", _sRate, 0, function()
-			local spamsecret = SECRET_CHATMESSAGES[math.random(#SECRET_CHATMESSAGES)]
-			RunConsoleCommand("say", spamsecret)
-			
-		end)
-	end
-
-	if secret.config_get("bCustom") then
-		secret.log("replace anything in the CUSTOM_CHATMESSAGES table within the code!", 3)
-        secret.notify("check secret console for instructions")
-		timer.Create( "custom_spammer", _sRate, 0, function()
-			local spamCustom = CUSTOM_CHATMESSAGES[math.random(#CUSTOM_CHATMESSAGES)]
-			RunConsoleCommand("say", spamCustom)
-			
-		end)
-	end
-
-	if secret.config_get("bDestroy") then
-		timer.Remove( "oink_spammer" )
-		timer.Remove( "hvh_spammer" )
-		timer.Remove( "toxic_spammer" )
-		timer.Remove( "bible_spammer" )
-		timer.Remove( "custom_spammer" )
-		timer.Remove( "cheadle_spammer" )
-		timer.Remove( "newgen_spammer" )
-		timer.Remove( "fournier_spammer" )
-		timer.Remove( "femboy_spammer" ) -- femboy_spammer
-		timer.Remove( "shabeel_spammer" )
-		timer.Remove( "cat_spammer" )
-		timer.Remove( "secret_spammer" )
-	end
+secret.create_button("lua", "elements", "Destroy Timers", function()
+	timer.Remove("bOink_timer")
+	timer.Remove("bHvH_timer")
+	timer.Remove("bToxic_timer")
+	timer.Remove("bBible_timer")
+	timer.Remove("bCheadleware_timer")
+	timer.Remove("bNewGen_timer")
+	timer.Remove("bRyanFournier_timer")
+	timer.Remove("bFemboy_timer")
+	timer.Remove("bShabeel_timer")
+	timer.Remove("bCat_timer")
+	timer.Remove("bSecretService_timer")
+	timer.Remove("bCustom_timer")
+	secret.notify("All timers destroyed", 0)
 end)
 
+-- Messages
+local OINK_CHATMESSAGES = {"OINK.INDUSTRIES ON TOP, USE OINK.INDUSTRIES!", "Today's Killing Spree Is Sponsored By Oink.Industries!", "owned by oink. buy oink at oink.industries", "OINK OINK OINK OINK OINK OINK OINK OINK", "40 per year, 12 per month. cheap price for extra skill.", "chat is he using oink.industries?", "oink.industries - leading the cheating scene in 2023.", "you can buy a better cheat at oink.industries"}
+
+local HVHTALK_CHATMESSAGES = {"ur literally dog shit at this game!!!!!!", "nn dog? nn dog? nn dog? nn dog? nn dog? nn dog? ", [["why am i missing so much?!?!?!?!?" no fake angles in 2k23????]], "you can buy a better cheat at secretservice.club", "im winning too much bro. change up ur settings so u can beat me!!!!!!!!!", "using idiotbox?", "is ur nospread and norecoil working???", "nice aa retard lmao", "DID YOU SEE THAT BACKTRACK RIGHT THERE???", "secretservice.club > your cheat"}
+
+local TOXICTALK_CHATMESSAGES = {"HOLY SHIT YALL ARE HORRIBLE WTF", "MY KD IS SO MUCH BETTER THAN YOURS LOOOOOOOL", "YOU WANT TO 1V1 KID? ILL SLAP YOU LIKE YOUR MOTHER", "EZZZZZZZZZZZZZZZZZ EZZZZZZZZZZZZZ NO OINK NO TALK", [["YO WHAT CHEAT IS THAT WHAT CHEAT" SECRETSERVICE.CLUB ON TOPPPP]], "crash! poof! gone! vaporized! destroyed!", "lol you literally got owned by a child.", "I WILL DOMINATE YOU BECAUSE IM YOUR MASTER, KITTEN...", "HAHAHAHHAHAH OWNEDDDDDDDDDDDDDDDDD", "FEELS LIKE TACOBOT.TF. IN REALITY, IM JUST BETTER."}
+
+local BIBLE_CHATMESSAGES = {[["Ask and it will be given to you." - Jesus (Matthew 7:7)]], [["Faith can move mountains." - Jesus (Matthew 17:20)]], [["I am the way, the truth, and the life." - Jesus (John 14:6)]], [["Cast your cares on the Lord." - David (Psalm 55:22)]], [["Seek and you will find." - Jesus (Matthew 7:7)]], [["The Lord is my light and salvation." - David (Psalm 27:1)]], [["Love covers a multitude of sins." - Peter (1 Peter 4:8)]], [["Do not worry, for I am with you." - Isaiah (Isaiah 41:10)]], [["A soft answer turns away wrath." - Solomon (Proverbs 15:1)]], [["Trust in the Lord with all your heart." - Solomon (Proverbs 3:5)]], [["I can do everything through Him." - Paul (Philippians 4:13)]], [["He heals the brokenhearted." - David (Psalm 147:3)]], [["The word of God is living and active." - Paul (Hebrews 4:12)]], [["Give thanks in all circumstances." - Paul (1 Thessalonians 5:18)]], [["The Lord will fight for you." - Moses (Exodus 14:14)]]}
+
+local CHEADLEWARE_CHATMESSAGES = {"Cheadleware on top! Buy now on cheadleware.net", "she cheadle on my software whilst spy caming on them hoes with screengrab proof visuals", "This server has been backdoored by cheadleware. Please be scared I need attention", "UKRAINE PIG OWNS YOU!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!", "Cheadleware merch coming soon!", "BUY CHEADLEWARE BUY CHEADLEWARE BUY CHEADLEWARE BUY CHEADLEWARE BUY CHEADLEWARE BUY CHEADLEWARE", "Did you know you can buy cheadleware for 40 dollars only? It's lifetime too. It's kinda crazy...", "https://i.imgur.com/lIa2bkE.png cheadlware cake looks so good. you want a slice?", "cheadleware.net", "cheadleware.net cheadleware.net cheadleware.net cheadleware.net cheadleware.net cheadleware.net cheadleware.net"}
+
+local NEWGEN_CHATMESSAGES = {"Skibidi Dop Dop Dop Yes Yes? Skibidi Dopolo Diep Diep?", "Sticking Out Your Gyat For The Rizzler, You're So Skibidi, So Fanum Tax.", "OH MY GOOWDDDDDDD LOOK AT THAT GYATTTTTTT", "PLEASE NO PROTECT ME FROM THE CAMERAMEN THEY ATTACK ME AND FAMILY OF SKIBIDI TOILETS HELP MEEEEEEEEE", "SKIBIDI OWNS YOUR SERVER AND GM_BIGCITY. YOU HAVE NO ESCAPE MUAHAHAHAHAHAHHAHAHHAHHAHAHHHAAAAAA", "I just wanna be your sigma, Freaking come here, Give me your ohio.", "You're not a sigma male like me. You're a fat loser. Escape the matrix with hustlers university 2.0...", "That's so fruity uwu", "Did it hurt? When you fell out of heaven? Generated by RizzApp.io", "ULTIMATE RIZZ LOADING... 5%... 30%... 70%... 99%... ERROR, SKIBIDI TOILET HACKER DETECTED DEFENDING ATTACK!!!", "womp womp"}
+
+local RYANFOURNIER_CHATMESSAGES = {"Your server has been backdoored by evil ryan fournier. Changing level to prometheus_berlin_v2...", "Evil Ryan Fournier has access to your computer. Your firewall has been jumped. Say goodbye to your files...", "IM GONNA PISTOL WHIP THE SHIT OUT OF YOU HAHAHAHAHAHAHAHAHAHAHAH", "Students4Trump Sponsors this daily segment of raping garry's mod servers. Please donate to our ORG.", "My wife was my first target, this server is my second target. *he grips his gun harder and harder*", "Injecting evil_ryan_fournier_backdoor_services_dll_main_application.exe into server code...", "RATTED BY EVILRYANFOURNIER! evilryanfournier.com!"}
+
+local FEMBOY_CHATMESSAGES = {"h-hey. I'm a small little femboy. D-do you want to co-orrupt me? I'm a si-ssy femboy.", "I'm into tall and big guys so they can hold me and tell me how much of a good boy I am...", "p-p-PLEASE MAASTER GI-IIIVE ME MO-RE O-OF THAT *moaning*", "I'm my master's little s-slut. He can do whatever he wants to me and my b-b-body...", "I have my vibrator set to low as we speak... I-it feels so go-oood", "Master here. My helpless little slut here is such a good girl... He always begs for more like a good soul...", "Being a submissive little femboy slut feels so good. I like not having rights.", "You can p-pinch and twist both of my nipples. They're very sensitive and round.", "I remember when I was t-ied up for hours with a dildo pumping into me. My a-ass has never been the same...", "I'm the #385923th cumdump in the world. You can use me for free uwu.", "P-Please DM me on discord. My name is 'iamleigh_'. E-Dating Prices are 5-10€ an hour."}
+
+local SHABEEL_CHATMESSAGES = {"OWNED BY SHABEEL EXPLOITS - discord.gg/gaminglight", "This server has officially been raided by shabeel. May allah power him through gmod servers", "discord.gg/gaminglight", "SHABEEL OWNS YOUUUUUUUUUUUUUUUUUUUUUUUUUU", "youtube.com/@ShabeelExploits I love this youtube channel can someone help me find them?", "Hello I have downloaded server packet via epic exploit server is being backdoored SHABEEL WINNING", "SHABEEL ON TOP OWNED BY SHABEEL"}
+
+local CAT_CHATMESSAGES = {"meow", "meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow meow", "prrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr", "WHO LEFT THE ENGINE RUNNINGGGG", "wake up, eep.", "Today's Chat Spam Is Brough To You By The One And Only Thousand Meow Stare", "growling noises are soooooo cute grrrrrprrrr"}
+
+local SECRET_CHATMESSAGES = {"secretservice on top! get at secretservice.club", "Get Good, Get secretservice.club", "Want the best gmod cheat, Get secretservice.club", "SecretService.club owns you!!", "SecretService.club owns me!! UwU", "SecretService.club SecretService.club SecretService.club SecretService.club SecretService.club SecretService.club", "SecretService.club > any cheat", "1v1 me bro, SecretService.club on TOPP!!!", "YOU WISH YOU HAVE SECRETSERVICE.CLUB", "https://imgur.com/a/qZrfSrO SECRETSERVICE.CLUB OWNS YOU!!!", "LSAC? ROTAC? never heard of it, SECRETSERVICE.CLUB ON TOP!!", "hitting this secretservice.club OG joint"}
+
+-- Replace these with whatever
+local CUSTOM_CHATMESSAGES = {"replace with custom message here", "replace with custom message here", "replace with custom message here", "replace with custom message here", "replace with custom message here", "replace with custom message here", "replace with custom message here", "replace with custom message here", "replace with custom message here", "replace with custom message here", "replace with custom message here", "replace with custom message here"}
+
+local function spamFunc(table, configName)
+	if not secret.config_get(configName) then return end
+
+	timer.Create(configName .. "_timer", secret.config_get("sRate"), 0, function()
+		local message = table[math.random(1, #table)]
+
+		if secret.config_get("bOOC") then
+			RunConsoleCommand("say", "/ooc " .. string.sub(message, 1, 126))
+		else
+			RunConsoleCommand("say", message)
+		end
+	end)
+end
+
+secret.event_remove("view_render_post", "cSpammer")
+
+secret.event_listen("view_render_post", "cSpammer", function()
+	spamFunc(OINK_CHATMESSAGES, "bOink")
+	spamFunc(HVHTALK_CHATMESSAGES, "bHvH")
+	spamFunc(TOXICTALK_CHATMESSAGES, "bToxic")
+	spamFunc(BIBLE_CHATMESSAGES, "bBible")
+	spamFunc(CHEADLEWARE_CHATMESSAGES, "bCheadleware")
+	spamFunc(NEWGEN_CHATMESSAGES, "bNewGen")
+	spamFunc(RYANFOURNIER_CHATMESSAGES, "bRyanFournier")
+	spamFunc(FEMBOY_CHATMESSAGES, "bFemboy")
+	spamFunc(SHABEEL_CHATMESSAGES, "bShabeel")
+	spamFunc(CAT_CHATMESSAGES, "bCat")
+	spamFunc(SECRET_CHATMESSAGES, "bSecretService")
+	spamFunc(CUSTOM_CHATMESSAGES, "bCustom")
+
+	if secret.config_get("bGir") then
+		secret.notify("bGir_timer couldn't start", 1)
+		secret.notify("check secret console for more info", 1)
+		secret.log("[chat-spammer.lua] to be in compliance of github's acceptable use policies, this spammer is removed.", 1, false)
+		secret.log("[chat-spammer.lua] if you want the uncensored version, you can ask lifeline4603 on discord or do one yourself.", 1, false)
+		secret.config_set("bGir", not secret.config_get("bGir"))
+	end
+end)


### PR DESCRIPTION
# DO NOT MERGE
- This PR has been merged into @retree1 PR. This is just here for information purposes 
# Changes
- Updated chat-spammer-secret to use checkboxs rather than buttons
- Removed think hook with view_render_post event
- Put the functionality when you clicked the checkbox (buttons) into one function to make cleaner


## Know bugs
- Does the chat spamming when its not ticked.. and doesnt do it when it is?
- When switching servers, youre required to clear, then run in client state again

## Misc
- This takes ooc spammer from #2 but does NOT include ULX spam
- Sub 100 lines 🥳🥳